### PR TITLE
Ibex: Use crosstool-ng to build toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 lowRISC toolchain builds
 ========================
 
-This repository contains tools to create toolchains for lowRISC internal use.
-The toolchains are *not supported* by lowRISC or recommended to be used outside of lowRISC.
+This repository contains tools to create toolchains for lowRISC internal
+use. The toolchains are *not supported* by lowRISC or recommended to be
+used outside of lowRISC.
 
-Head over to the GitHub releases for this repository for pre-built toolchains.
+Head over to the
+[GitHub releases for this repository](https://github.com/lowRISC/lowrisc-toolchains/releases)
+for pre-built toolchains.
+
+* A GCC RV32IMC without hardfloat support, targeting [Ibex](https://github.com/lowRISC/ibex/)
+* A GCC multilib toolchain
 
 How to do a release
 -------------------
@@ -12,19 +18,28 @@ How to do a release
 1. Modify `RISCV_GNU_TOOLCHAIN_COMMIT_ID` in `azure-pipelines.yml` and
    other build scripts and flags as needed.
 
-2. Tag a release
+2. Push the changes or do a pull request, and wait for the pipeline to
+   complete.
 
-  ```bash
-  VERSION=$(date +%Y%m%d)-1
-  git tag -a -m "Release version $VERSION" $VERSION
-  ```
+   The build can be tested by downloading the Azure Pipeline artifacts.
+     1. Go to the [lowrisc-toolchains Azure Pipelines page](https://dev.azure.com/lowrisc/lowrisc-toolchains/_build?definitionId=2&_a=summary)
+     2. Select a build
+     3. Click on "Artifacts" (top right)
+     4. Download the desired artifact, and test it.
 
-3. Push the tag
+3. Tag a release
 
-  ```bash
-  git push origin $VERSION
-  ```
+   ```bash
+   VERSION=$(date +%Y%m%d)-1
+   git tag -a -m "Release version $VERSION" $VERSION
+   ```
 
-Now the release builds on Azure Pipelines, and the resulting binaries
-will be uploaded to
-[GitHub releases](https://github.com/lowRISC/lowrisc-toolchains/releases).
+4. Push the tag
+
+   ```bash
+   git push origin $VERSION
+   ```
+
+   Now the release builds on Azure Pipelines, and the resulting binaries
+   will be uploaded to
+   [GitHub releases](https://github.com/lowRISC/lowrisc-toolchains/releases).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,9 @@ variables:
   RISCV_GNU_TOOLCHAIN_COMMIT_ID: 2e334e222d43bcde237c289385c977dcab81eda9
 
 trigger:
+  tags:
+    include:
+    - '*'
   branches:
     include:
     - master
@@ -18,26 +21,33 @@ jobs:
   timeoutInMinutes: 360
   steps:
   - bash: |
-      # Dependencies as listed at
-      # https://github.com/riscv/riscv-gnu-toolchain
-      sudo apt-get install -y autoconf automake autotools-dev curl \
-        libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison \
-        flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
+      sudo apt-get install -y build-essential autoconf bison flex \
+        texinfo help2man gawk libtool-bin libncurses5-dev git libtool \
+        gettext wget curl
     displayName: 'Install build dependencies'
 
   - bash: |
-      set -eux
+      ./install-crosstool-ng.sh
+    displayName: 'Build and install crosstool-ng'
 
-      sudo mkdir -p /tools/riscv
-      sudo chmod 777 /tools/riscv
-
-      ./build-gcc-ibex.sh
+  - bash: |
+      # crosstools-NG needs the ability to create and chmod the
+      # /tools/riscv directory.
+      sudo mkdir -p /tools \
+        && sudo chmod 777 /tools \
+        && mkdir -p /tools/riscv \
+        && ./build-gcc-ibex.sh
     displayName: 'Build GCC toolchain'
     env:
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
 
+  - publish: $(Build.ArtifactStagingDirectory)
+    artifact: gcc-ibex
+    displayName: "Upload GCC for Ibex as Azure artifact"
+
   - task: GithubRelease@0
     displayName: 'Upload to GitHub releases'
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
     inputs:
       gitHubConnection: lowrisc-artifact-upload
       repositoryName: lowrisc/lowrisc-toolchains
@@ -47,7 +57,6 @@ jobs:
       addChangeLog: false
       assetUploadMode: replace
       assets: |
-          $(Build.ArtifactStagingDirectory)/*.log
           $(Build.ArtifactStagingDirectory)/*.tar.xz
 
 - job: "GCC_Multilib"
@@ -65,18 +74,20 @@ jobs:
     displayName: 'Install build dependencies'
 
   - bash: |
-      set -eux
-
-      sudo mkdir -p /tools/riscv
-      sudo chmod 777 /tools/riscv
-
-      ./build-gcc-multilib.sh
+      sudo mkdir -p /tools/riscv \
+        && sudo chmod 777 /tools/riscv \
+        && ./build-gcc-multilib.sh
     displayName: 'Build GCC toolchain'
     env:
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
 
+  - publish: $(Build.ArtifactStagingDirectory)
+    artifact: gcc-multilib
+    displayName: "Upload multilib GCC builds as Azure artifact"
+
   - task: GithubRelease@0
     displayName: 'Upload to GitHub releases'
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
     inputs:
       gitHubConnection: lowrisc-artifact-upload
       repositoryName: lowrisc/lowrisc-toolchains
@@ -86,5 +97,4 @@ jobs:
       addChangeLog: false
       assetUploadMode: replace
       assets: |
-          $(Build.ArtifactStagingDirectory)/*.log
           $(Build.ArtifactStagingDirectory)/*.tar.xz

--- a/build-gcc-ibex.sh
+++ b/build-gcc-ibex.sh
@@ -27,16 +27,13 @@ ct-ng build
 
 ls -l /tools/riscv
 
-echo 'Version:' >> /tools/riscv/buildinfo
+echo -n 'lowRISC toolchain version: ' >> /tools/riscv/buildinfo
 git -C $TOP describe --always >> /tools/riscv/buildinfo
-echo >> /tools/riscv/buildinfo
 
-echo 'GCC version:' >> /tools/riscv/buildinfo
+echo -n 'GCC version: ' >> /tools/riscv/buildinfo
 /tools/riscv/bin/riscv32-unknown-elf-gcc --version | head -n1 >> /tools/riscv/buildinfo
-echo >> /tools/riscv/buildinfo
 
 echo "Built at $(date -u) on $(hostname)" >> /tools/riscv/buildinfo
-echo >> /tools/riscv/buildinfo
 
 tar -cJ \
   --directory=/tools \

--- a/build-gcc-ibex.sh
+++ b/build-gcc-ibex.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -x
+set -o pipefail
 
 TOP=$PWD
 
@@ -10,24 +11,24 @@ echo "##vso[task.setvariable variable=ReleaseTag]$TAG_NAME"
 
 TOOLCHAIN_NAME=lowrisc-toolchain-gcc-rv32imc-$TAG_NAME
 
+# XXX: This will create a toolchain in /tools/riscv/riscv32-unknown-elf
+# We curently use /tools/riscv directly, which is set through CT_PREFIX_DIR in
+# the config file. If we decide to go for a triple-specific toolchain subdir,
+# we can go back to using this setting here, and remove CT_PREFIX_DIR from the
+# config.
+#export CT_PREFIX=/tools/riscv
+
 mkdir -p build/gcc
 cd build/gcc
-git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
-cd riscv-gnu-toolchain
-git checkout $RISCV_GNU_TOOLCHAIN_COMMIT_ID
-./configure --prefix=/tools/riscv \
-    --with-abi=ilp32 \
-    --with-arch=rv32imc \
-    --with-cmodel=medany 2>&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLCHAIN_NAME.log
-make -j$(nproc) 2>&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLCHAIN_NAME.log
-# Includes make install
+cp ../../lowrisc-toolchain-gcc-rv32imc.config .config
+ct-ng upgradeconfig
+cat .config
+ct-ng build
+
+ls -l /tools/riscv
 
 echo 'Version:' >> /tools/riscv/buildinfo
 git -C $TOP describe --always >> /tools/riscv/buildinfo
-echo >> /tools/riscv/buildinfo
-
-echo 'Version of https://github.com/riscv/riscv-gnu-toolchain:' >> /tools/riscv/buildinfo
-git -C $TOP/build/gcc/riscv-gnu-toolchain describe --always >> /tools/riscv/buildinfo
 echo >> /tools/riscv/buildinfo
 
 echo 'GCC version:' >> /tools/riscv/buildinfo

--- a/build-gcc-multilib.sh
+++ b/build-gcc-multilib.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -x
+set -o pipefail
 
 TOP=$PWD
 

--- a/build-gcc-multilib.sh
+++ b/build-gcc-multilib.sh
@@ -30,20 +30,16 @@ make -j$(( `nproc` * 2 )) linux 2>&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLC
 
 make -j$(( `nproc` * 2 )) build-qemu 2?&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLCHAIN_NAME.log
 
-echo 'Version:' >> /tools/riscv/buildinfo
+echo -n 'lowRISC toolchain version: ' >> /tools/riscv/buildinfo
 git -C $TOP describe --always >> /tools/riscv/buildinfo
-echo >> /tools/riscv/buildinfo
 
-echo 'Version of https://github.com/riscv/riscv-gnu-toolchain:' >> /tools/riscv/buildinfo
+echo -n 'Version of https://github.com/riscv/riscv-gnu-toolchain:' >> /tools/riscv/buildinfo
 git -C $TOP/build/gcc/riscv-gnu-toolchain describe --always >> /tools/riscv/buildinfo
-echo >> /tools/riscv/buildinfo
 
-echo 'GCC version:' >> /tools/riscv/buildinfo
+echo -n 'GCC version: ' >> /tools/riscv/buildinfo
 /tools/riscv/elf/bin/riscv64-unknown-elf-gcc --version | head -n1 >> /tools/riscv/buildinfo
-echo >> /tools/riscv/buildinfo
 
 echo "Built at $(date -u) on $(hostname)" >> /tools/riscv/buildinfo
-echo >> /tools/riscv/buildinfo
 
 tar -cJ \
   --directory=/tools \

--- a/build-gcc-multilib.sh
+++ b/build-gcc-multilib.sh
@@ -19,16 +19,16 @@ git checkout $RISCV_GNU_TOOLCHAIN_COMMIT_ID
 
 # Build ELF Multilib
 ./configure --prefix=/tools/riscv/elf \
-    --enable-multilib 2>&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLCHAIN_NAME.log
-make -j$(( `nproc` * 2 )) 2>&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLCHAIN_NAME.log
+    --enable-multilib
+make -j$(( `nproc` * 2 ))
 
 make clean
 # Build Linux Multilib
 ./configure --prefix=/tools/riscv/linux \
-    --enable-multilib 2>&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLCHAIN_NAME.log
-make -j$(( `nproc` * 2 )) linux 2>&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLCHAIN_NAME.log
+    --enable-multilib
+make -j$(( `nproc` * 2 )) linux
 
-make -j$(( `nproc` * 2 )) build-qemu 2?&1 | tee --append $ARTIFACT_STAGING_DIR/$TOOLCHAIN_NAME.log
+make -j$(( `nproc` * 2 )) build-qemu
 
 echo -n 'lowRISC toolchain version: ' >> /tools/riscv/buildinfo
 git -C $TOP describe --always >> /tools/riscv/buildinfo

--- a/install-crosstool-ng.sh
+++ b/install-crosstool-ng.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CROSSTOOL_NG_VERSION=3f461da11f1f8e9dcfdffef24e1982b5ffd10305
+
+mkdir -p build && cd build || exit 1
+git clone https://github.com/crosstool-ng/crosstool-ng || exit 1
+cd crosstool-ng
+git checkout $CROSSTOOL_NG_VERSION || exit 1
+./bootstrap || exit 1
+./configure --prefix=/usr/local && make && sudo make install

--- a/lowrisc-toolchain-gcc-rv32imc.config
+++ b/lowrisc-toolchain-gcc-rv32imc.config
@@ -1,0 +1,26 @@
+CT_CONFIG_VERSION="3"
+CT_EXPERIMENTAL=y
+CT_ARCH_RISCV=y
+CT_ARCH_ARCH="rv32imc"
+CT_ARCH_ABI="ilp32"
+CT_TARGET_VENDOR=""
+# CT_CC_GCC_LDBL_128 is not set
+CT_CC_LANG_CXX=y
+CT_DEBUG_GDB=y
+CT_GDB_V_8_2=y
+# CT_GDB_CROSS_PYTHON is not set
+CT_ISL_V_0_20=y
+
+# Disable progress bar for CI builds, it generates too much log output
+# CT_LOG_PROGRESS_BAR is not set
+
+# Installation prefix directory; the toolchain will end up in exactly
+# this directory.
+CT_PREFIX_DIR="/tools/riscv"
+
+# Don't save tarballs for re-use (needs writable and pre-created
+# CT_LOCAL_TARBALLS_DIR otherwise)
+# CT_SAVE_TARBALLS is not set
+
+# Don't chmod the CT_PREFIX_DIR read-only after the install.
+# CT_PREFIX_DIR_RO is not set


### PR DESCRIPTION
crosstool-ng is significantly cleaner than the SiFive-provided toolchain
build script.