### PR TITLE
[Ibex] Disable Bitmanip in Libraries

### DIFF
--- a/lowrisc-toolchain-gcc-rv32imc.config
+++ b/lowrisc-toolchain-gcc-rv32imc.config
@@ -1,8 +1,23 @@
 CT_CONFIG_VERSION="3"
 CT_EXPERIMENTAL=y
+
 CT_ARCH_RISCV=y
-CT_ARCH_ARCH="rv32imcb"
+
+# CT_ARCH_ARCH controls the specific architecture that the toolchain's libraries
+# are built with. It should specify the minimum RISC-V extensions that need to
+# be implemented by any processor that this toolchain will compile programs for.
+#
+# 2020-03-26: We have added B extension (v0.92) support to the compiler using
+#             experimental patches, but we still want to support Ibex without
+#             the B extension, so this remains "rv32imc".
+#
+CT_ARCH_ARCH="rv32imc"
+
+# CT_ARCH_ABI controls the specific ABI that the toolchain's libraries are built
+# with. All programs built against this toolchain should follow exactly this
+# ABI.
 CT_ARCH_ABI="ilp32"
+
 CT_TARGET_VENDOR=""
 # CT_CC_GCC_LDBL_128 is not set
 CT_CC_LANG_CXX=y


### PR DESCRIPTION
We now build the toolchain (including libraries) with only rv32imc (as
before we landed the bitmanip patches). With the B extension compiler
and binutils patches landed, the compiler should still be able to
compile for cores with the +B extension, but this change prevents issues
if your core does not implement the B extension, which is the case for
mainline Ibex today.

Code with the B extension enabled should be linkable with libraries with
the B extension disabled.

---

Closes #12 (if it builds).