### PR TITLE
Downgrade RV32IMC GCC to 9.2.0

### DIFF
--- a/lowrisc-toolchain-gcc-rv32imc.config
+++ b/lowrisc-toolchain-gcc-rv32imc.config
@@ -43,17 +43,5 @@ CT_PREFIX_DIR="/tools/riscv"
 # Don't chmod the CT_PREFIX_DIR read-only after the install.
 # CT_PREFIX_DIR_RO is not set
 
-# We apply the binutils bitmanip patches on top of git commit 612aac65
-CT_BINUTILS_SRC_DEVEL=y
-CT_BINUTILS_DEVEL_VCS_git=y
-CT_BINUTILS_DEVEL_URL="https://github.com/bminor/binutils-gdb.git"
-CT_BINUTILS_DEVEL_REVISION="612aac65e690387c963c34a31dd1fb138d88a45c"
-
-# We apply the gcc bitmanip patches on top of git commit 49f75e008c0
-CT_GCC_SRC_DEVEL=y
-CT_GCC_DEVEL_VCS_git=y
-CT_GCC_DEVEL_URL="https://github.com/riscv/riscv-gcc.git"
-CT_GCC_DEVEL_REVISION="49f75e008c0809eb3c74a163297b4aa8925c9f1c"
-
 # The build script appends a definition of CT_LOCAL_PATCH_DIR down here, that
 # points to the repo's patch directory.


### PR DESCRIPTION
With the previous config, we were accidentally building a GCC 10.0.0
experimental version of GCC. In order to make the toolchain migration go
as smoothly as possible for OpenTitan, I'm reverting to building the
same version as we were building before (9.2.0).

I will follow-up with a patch that includes the config for RV32IMC+B, as
this does require a git version of GCC because we apply patches on top
of it.

Signed-off-by: Sam Elliott <selliott@lowrisc.org>