### PR TITLE
Add kind field to buildinfo.json

### DIFF
--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -171,6 +171,7 @@ BUILDINFO
 tee "${toolchain_dest}/buildinfo.json" <<BUILDINFO_JSON
 {
   "toolchain_config": "${toolchain_name}",
+  "kind: "combined",
   "version": "${tag_name}",
   "clang_version": "${clang_version_string}",
   "clang_git": "${LLVM_VERSION}",

--- a/build-gcc-with-args.sh
+++ b/build-gcc-with-args.sh
@@ -149,6 +149,7 @@ BUILDINFO
 tee "${toolchain_dest}/buildinfo.json" <<BUILDINFO_JSON
 {
   "toolchain_config": "${toolchain_name}",
+  "kind: "gcc-only",
   "version": "${tag_name}",
   "gcc_version": "${gcc_version_string}",
   "qemu_version": "${qemu_version_string}",


### PR DESCRIPTION
This helps OpenTitan's `get-toolchain.py` tool differentiate between the GCC
and GCC+Clang toolchains, even if they have the same version.