### PR TITLE
Set ReleaseTag More Accurately

### DIFF
--- a/_build-deps.yml
+++ b/_build-deps.yml
@@ -13,3 +13,35 @@ steps:
 - bash: |
     ./install-crosstool-ng.sh
   displayName: 'Build and install crosstool-ng'
+
+- bash: |
+    set -e
+    git fetch --tags
+
+    # git-describe --always almost does what we want, but we need to connect the
+    # ReleaseTag variable contents to how this build was triggered, which we
+    # will find out using `Build.SourceBranch` (a pipeline varaible).
+    #
+    # Importantly, a few things are going on here:
+    # - If we were triggered by a tag, we need to set ReleaseTag to exactly the
+    #   tag name, so that the artifacts are named correctly. If we cannot do
+    #   this, the build needs to fail rather than uploading artifacts to some
+    #   other random tag.
+    # - If we were triggered by a branch build, we need to be more careful, as
+    #   tagged commits are also pushed to branches. Branch builds explicitly use
+    #   the longer format so that if the built commit matches a tag, the
+    #   ReleaseTag is not a tag name.
+    #
+    # This is partly caused by azure not always pulling down tags when checking
+    # out a repo, so we fetch tags again, above, just to make sure we have all
+    # current tags.
+    if [[ "$(Build.SourceBranch)" == refs/tags/* ]]; then
+      # Tag Build: Always use '<TAG>' format; Error if tag not found.
+      tag_name="$(git describe --exact-match)"
+    else
+      # Branch Build: Always use '<TAG>-<N>-<SHA>' format.
+      tag_name="$(git describe --long)"
+    fi
+
+    echo "##vso[task.setvariable variable=ReleaseTag]${tag_name}"
+  displayName: 'Set ReleaseTag'

--- a/_upload-artifacts.yml
+++ b/_upload-artifacts.yml
@@ -15,5 +15,7 @@ steps:
     addChangeLog: false
     assetUploadMode: replace
     isPreRelease: true
+    # To ensure assets match the tag we're uploading to, we only upload assets
+    # that end with `$(ReleaseTag).tar.xz`
     assets: |
-        $(Build.ArtifactStagingDirectory)/*.tar.xz
+      $(Build.ArtifactStagingDirectory)/*-$(ReleaseTag).tar.xz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
     displayName: 'Build GCC toolchain'
     env:
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+      RELEASE_TAG: $(ReleaseTag)
 
   - bash: |
       ./build-clang-with-args.sh \
@@ -42,6 +43,7 @@ jobs:
     displayName: "Build Clang toolchain"
     env:
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+      RELEASE_TAG: $(ReleaseTag)
 
   - template: "_upload-artifacts.yml"
     parameters:
@@ -64,6 +66,7 @@ jobs:
     displayName: 'Build GCC toolchain'
     env:
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+      RELEASE_TAG: $(ReleaseTag)
 
   - bash: |
       ./build-clang-with-args.sh \
@@ -73,6 +76,7 @@ jobs:
     displayName: "Build Clang toolchain"
     env:
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+      RELEASE_TAG: $(ReleaseTag)
 
   - template: "_upload-artifacts.yml"
     parameters:
@@ -95,6 +99,7 @@ jobs:
     displayName: 'Build GCC toolchain'
     env:
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+      RELEASE_TAG: $(ReleaseTag)
 
   - bash: |
       ./build-clang-with-args.sh \
@@ -104,6 +109,7 @@ jobs:
     displayName: "Build Clang toolchain"
     env:
       ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+      RELEASE_TAG: $(ReleaseTag)
 
   - template: "_upload-artifacts.yml"
     parameters:

--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -42,8 +42,7 @@ build_top_dir="${PWD}"
 # shellcheck source=sw-versions.sh
 source "${build_top_dir}/sw-versions.sh"
 
-git -C "${build_top_dir}" fetch --tags
-tag_name="$(git -C "${build_top_dir}" describe --always)"
+tag_name="${RELEASE_TAG:-HEAD}"
 toolchain_full_name="${toolchain_name}-${tag_name}"
 
 mkdir -p "${build_top_dir}/build"

--- a/build-gcc-with-args.sh
+++ b/build-gcc-with-args.sh
@@ -39,12 +39,7 @@ build_top_dir="${PWD}"
 # shellcheck source=sw-versions.sh
 source "${build_top_dir}/sw-versions.sh"
 
-git -C "${build_top_dir}" fetch --tags
-tag_name="$(git -C "${build_top_dir}" describe --always)"
-set +x
-echo "##vso[task.setvariable variable=ReleaseTag]${tag_name}"
-set -x
-
+tag_name="${RELEASE_TAG:-HEAD}"
 toolchain_full_name="${toolchain_name}-${tag_name}"
 
 # crosstools-NG needs the ability to create and chmod the


### PR DESCRIPTION
---

The idea here is to use a separate, short, bash script to set `ReleaseTag`, and then for all tasks to use the same `ReleaseTag` value, rather than the GCC build setting it and the clang build potentially using a different tag.

We also do a few things that support this:
- If this is a tag build, we definitely use the tag.
- If it's a branch build, we use the `<tag>-<n>-<sha>` format.
- We only upload artefacts that have a name that matches the ReleaseTag.
