### PR TITLE
Allow build-*-with-args.sh to run locally

### DIFF
--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -184,10 +184,12 @@ tee "${toolchain_dest}/buildinfo.json" <<BUILDINFO_JSON
 }
 BUILDINFO_JSON
 
+artifact_dir="${ARTIFACT_STAGING_DIR:-${build_top_dir}/build}"
+
 # Package up toolchain directory
 tar -cJ \
   --directory="$(dirname "${toolchain_dest}")" \
-  -f "$ARTIFACT_STAGING_DIR/$toolchain_full_name.tar.xz" \
+  -f "${artifact_dir}/${toolchain_full_name}.tar.xz" \
   --transform="s@$(basename "${toolchain_dest}")@$toolchain_full_name@" \
   --owner=0 --group=0 \
   "$(basename "${toolchain_dest}")"

--- a/build-gcc-with-args.sh
+++ b/build-gcc-with-args.sh
@@ -160,11 +160,13 @@ tee "${toolchain_dest}/buildinfo.json" <<BUILDINFO_JSON
 }
 BUILDINFO_JSON
 
+artifact_dir="${ARTIFACT_STAGING_DIR:-${build_top_dir}/build}"
+
 # Package up toolchain directory
 tar -cJ \
   --show-transformed-names --verbose \
   --directory="$(dirname "${toolchain_dest}")" \
-  -f "$ARTIFACT_STAGING_DIR/$toolchain_full_name.tar.xz" \
-  --transform="flags=rhS;s@^$(basename "${toolchain_dest}")@$toolchain_full_name@" \
+  -f "${artifact_dir}/${toolchain_full_name}.tar.xz" \
+  --transform="flags=rhS;s@^$(basename "${toolchain_dest}")@${toolchain_full_name}@" \
   --owner=0 --group=0 \
   "$(basename "${toolchain_dest}")"


### PR DESCRIPTION
Developers run into issues trying to run `build-clang-with-args.sh` and `build-gcc-with-args.sh` on their own machines. 

I think the usual bug report is because they don't have `ARTIFACT_STAGING_DIR` set in their environment. This commit ensures the final artifact is put somewhere sensible (and likely writable) if that env variable is not present.