### PR TITLE
[clang] Correct tar filename Transform

### DIFF
--- a/_upload-artifacts.yml
+++ b/_upload-artifacts.yml
@@ -3,6 +3,19 @@ steps:
   artifact: ${{ parameters.azure_name }}
   displayName: "Upload Azure Artifact"
 
+# This comes after uploading azure artifacts so we can debug the azure artifact
+# if this step fails.
+- bash: |
+    set -e
+    find "${ARTIFACT_STAGING_DIR}" \
+      -type f \
+      -name "*.tar.xz" \
+      -print0 \
+      | xargs -0 -n1 ./check-tarball-symlinks.sh
+  env:
+    ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+  displayName: "Checking Artifact Tarballs"
+
 - task: GithubRelease@0
   displayName: 'Upload GitHub Release (if tagged)'
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))

--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -118,6 +118,8 @@ cmake --build "${llvm_build_dir}" \
   --parallel $(( $(nproc) + 2 )) \
   --target install-distribution
 
+cd "${build_top_dir}"
+
 ## Create Toolchain Files!
 # These don't yet add cflags ldflags
 "${build_top_dir}/generate-clang-cmake-toolchain.sh" \
@@ -184,11 +186,12 @@ tee "${toolchain_dest}/buildinfo.json" <<BUILDINFO_JSON
 }
 BUILDINFO_JSON
 
+# If `ARTIFACT_STAGING_DIR` is not set, we don't want to leave the final binary
+# in the root directory.
+artifact_dir="${ARTIFACT_STAGING_DIR:-${build_top_dir}/build}"
+
 # Package up toolchain directory
-tar -cJ \
-  --show-transformed-names --verbose \
-  --directory="$(dirname "${toolchain_dest}")" \
-  -f "$ARTIFACT_STAGING_DIR/$toolchain_full_name.tar.xz" \
-  --transform="flags=rhS;s@^$(basename "${toolchain_dest}")@$toolchain_full_name@" \
-  --owner=0 --group=0 \
-  "$(basename "${toolchain_dest}")"
+"${build_top_dir}/create-prefixed-archive.sh" \
+  "${toolchain_full_name}" \
+  "${toolchain_dest}" \
+  "${artifact_dir}"

--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -186,8 +186,9 @@ BUILDINFO_JSON
 
 # Package up toolchain directory
 tar -cJ \
+  --show-transformed-names --verbose \
   --directory="$(dirname "${toolchain_dest}")" \
   -f "$ARTIFACT_STAGING_DIR/$toolchain_full_name.tar.xz" \
-  --transform="s@$(basename "${toolchain_dest}")@$toolchain_full_name@" \
+  --transform="flags=rhS;s@^$(basename "${toolchain_dest}")@$toolchain_full_name@" \
   --owner=0 --group=0 \
   "$(basename "${toolchain_dest}")"

--- a/build-gcc-with-args.sh
+++ b/build-gcc-with-args.sh
@@ -100,7 +100,7 @@ cp "${qemu_dir}/LICENSE" "${toolchain_dest}/share/licenses/qemu"
 cp "${qemu_dir}/COPYING" "${toolchain_dest}/share/licenses/qemu"
 cp "${qemu_dir}/COPYING.LIB" "${toolchain_dest}/share/licenses/qemu"
 
-cd "${build_top_dir}/build/gcc"
+cd "${build_top_dir}"
 
 ## Create Toolchain Files!
 # These don't yet add cflags ldflags
@@ -157,11 +157,12 @@ tee "${toolchain_dest}/buildinfo.json" <<BUILDINFO_JSON
 }
 BUILDINFO_JSON
 
+# If `ARTIFACT_STAGING_DIR` is not set, we don't want to leave the final binary
+# in the root directory.
+artifact_dir="${ARTIFACT_STAGING_DIR:-${build_top_dir}/build}"
+
 # Package up toolchain directory
-tar -cJ \
-  --show-transformed-names --verbose \
-  --directory="$(dirname "${toolchain_dest}")" \
-  -f "$ARTIFACT_STAGING_DIR/$toolchain_full_name.tar.xz" \
-  --transform="flags=rhS;s@^$(basename "${toolchain_dest}")@$toolchain_full_name@" \
-  --owner=0 --group=0 \
-  "$(basename "${toolchain_dest}")"
+"${build_top_dir}/create-prefixed-archive.sh" \
+  "${toolchain_full_name}" \
+  "${toolchain_dest}" \
+  "${artifact_dir}"

--- a/check-tarball-symlinks.sh
+++ b/check-tarball-symlinks.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+## check-tarball-symlinks.sh
+#
+# Takes a tarball name and checks all symlinks resolve to an existing file. This
+# has been an issue we keep running into, so CI can now check it for us!
+
+set -e
+set -x
+set -o pipefail
+
+if ! [ "$#" = 1 ]; then
+  echo "Usage: $0 <tarball>"
+  exit 2
+fi;
+
+tarball="$1"
+tarball_dest="$(mktemp -d)"
+
+echo "Checking: $1"
+
+# Extract tarball into `tarball_dest`
+echo "Extracting:"
+tar -x -v \
+  -f "${tarball}" \
+  --strip-components=1 \
+  -C "${tarball_dest}"
+
+broken_symlinks="$(mktemp)"
+
+# Check for broken symlinks
+echo "Broken Symlinks:"
+find "${tarball_dest}" -type l \
+  -exec test ! -e '{}' \; \
+  -print | tee "${broken_symlinks}"
+
+if [ -s "${broken_symlinks}" ]; then
+  echo "ERROR: Broken Symlinks Found"
+  exit 1
+fi

--- a/create-prefixed-archive.sh
+++ b/create-prefixed-archive.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This will tar-up $toolchain_dest into a tar called $toolchain_full_name.tar.xz
+#
+# All files in that tarball will be in a directory called $toolchain_full_name,
+# not $(basename $toolchain_dest).
+
+set -e
+set -x
+set -o pipefail
+
+if ! [ "$#" = 3 ]; then
+  echo "Usage: $0 <toolchain_name> <toolchain_dest> <artifact_dir>"
+  exit 2
+fi;
+
+# These arguments are provided by `./build-*-with-args.sh`
+toolchain_full_name="$1"
+toolchain_dest="$2"
+artifact_dir="${3:-.}"
+
+tar -cJ \
+  --show-transformed-names --verbose \
+  --directory="$(dirname "${toolchain_dest}")" \
+  -f "${artifact_dir}/$toolchain_full_name.tar.xz" \
+  --transform="flags=rhS;s@^$(basename "${toolchain_dest}")@$toolchain_full_name@" \
+  --owner=0 --group=0 \
+  "$(basename "${toolchain_dest}")"


### PR DESCRIPTION
This is now the same one that we use for gcc. The reason for this is
because we're tar-ing up some files that GCC produces too. The transform
was wrong for GCC in the past, and this ports that fix onto current
master.

---

Issue noted by @imphil in https://github.com/lowRISC/opentitan/pull/2524#issuecomment-645360269