### PR TITLE
[gnu] Override CT_PREFIX_DIR Correctly

### DIFF
--- a/build-gcc-with-args.sh
+++ b/build-gcc-with-args.sh
@@ -54,7 +54,8 @@ cd "${build_top_dir}/build/gcc"
 
 # Create crosstool-ng config file with correct `CT_PREFIX_DIR` and `CT_LOCAL_PATCH_DIR`
 {
-  cat "${build_top_dir}/${toolchain_name}.config";
+  cat "${build_top_dir}/${toolchain_name}.config" \
+    | grep -v '^CT_PREFIX_DIR=';
   echo "";
   echo "# ADDED BY ${0}";
   echo "CT_PREFIX_DIR=\"${toolchain_dest}\"";


### PR DESCRIPTION
In some azure logs I was seeing messages that said `CT_PREFIX_DIR` set twice, and was confused, but looking at the .config files, some do contain `CT_PREFIX_DIR=`. This removes them and means we can override them with `$toolchain_dest` correctly.