### PR TITLE
Fix code model for Muntjac libraries

### DIFF
--- a/lowrisc-toolchain-gcc-rv64imac.config
+++ b/lowrisc-toolchain-gcc-rv64imac.config
@@ -14,6 +14,8 @@ CT_ARCH_ARCH="rv64imac"
 # ABI.
 CT_ARCH_ABI="lp64"
 
+CT_TARGET_CFLAGS="-mcmodel=medany"
+
 CT_TARGET_VENDOR=""
 CT_TOOLCHAIN_BUGURL="toolchains@lowrisc.org"
 


### PR DESCRIPTION
Attempting to address #42.

An alternative I've seen is to add `-mcmodel=medany` to `CFLAGS_FOR_TARGET`, but I can't immediately see how to do that.