### PR TITLE
Tidy Muntjac GCC configuration flags

### DIFF
--- a/lowrisc-toolchain-gcc-rv64imac.config
+++ b/lowrisc-toolchain-gcc-rv64imac.config
@@ -14,10 +14,10 @@ CT_ARCH_ARCH="rv64imac"
 # ABI.
 CT_ARCH_ABI="lp64"
 
-CT_TARGET_CFLAGS="-mcmodel=medany"
-
 CT_TARGET_VENDOR=""
 CT_TOOLCHAIN_BUGURL="toolchains@lowrisc.org"
+
+CT_CC_GCC_EXTRA_CONFIG_ARRAY=--with-cmodel=medany
 
 CT_CC_GCC_STATIC_LIBSTDCXX=y
 # CT_CC_GCC_LDBL_128 is not set


### PR DESCRIPTION
Following advice from @luismarques in #43 to avoid overwriting `CFLAGS`. There should be no difference in behaviour.