### PR TITLE
Update toolchain with hardening patches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,48 +15,8 @@ pr:
     - '*'
 
 jobs:
-- job: "Toolchains_RV32IMC"
-  displayName: "Toolchains targeting Ibex"
-  pool:
-    vmImage: "ubuntu-20.04"
-  container: lowrisc/lowrisc-base-centos6:latest
-  timeoutInMinutes: 360
-  steps:
-  - template: "_build-deps.yml"
-
-  - bash: |
-      sudo mkdir -p /tools/riscv
-      sudo chmod 0777 /tools/riscv
-    displayName: "Prepare toolchain destination directory"
-
-  - bash: |
-      ./build-gcc-with-args.sh \
-        "lowrisc-toolchain-gcc-rv32imc" \
-        "riscv32-unknown-elf" \
-        "/tools/riscv" \
-        "rv32imc" "ilp32" "medany"
-    displayName: 'Build GCC toolchain'
-    env:
-      ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
-      RELEASE_TAG: $(ReleaseTag)
-
-  - bash: |
-      ./build-clang-with-args.sh \
-        "lowrisc-toolchain-rv32imc" \
-        "riscv32-unknown-elf" \
-        "/tools/riscv" \
-        "rv32imc" "ilp32" "medany"
-    displayName: "Build Clang toolchain"
-    env:
-      ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
-      RELEASE_TAG: $(ReleaseTag)
-
-  - template: "_upload-artifacts.yml"
-    parameters:
-      azure_name: rv32imc-toolchains
-
 - job: "Toolchains_RV32IMCB"
-  displayName: "Toolchains targeting Ibex with 'Balanced' Bit-manipulation"
+  displayName: "Toolchains targeting Ibex with bit-manipulation extensions"
   # These builds are using the ratified bitmanip extensions, version 1.0: Zba,
   # Zbb, Zbc, and Zbs. For the current version of Clang we need to specify them
   # as version 0.93, but they should be equivalent.

--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -57,7 +57,7 @@ cd "${build_top_dir}/build"
 
 llvm_dir="${build_top_dir}/build/llvm-project"
 if [ ! -d "${llvm_dir}" ]; then
-  git clone ${LLVM_URL} "${llvm_dir}"
+  git clone --branch ${LLVM_BRANCH} ${LLVM_URL} "${llvm_dir}"
 fi
 cd "${llvm_dir}"
 git fetch origin

--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -48,12 +48,6 @@ build_top_dir="${PWD}"
 # shellcheck source=sw-versions.sh
 source "${build_top_dir}/sw-versions.sh"
 
-if [[ "${toolchain_name}" == *-rv32imcb ]]; then
-  llvm_version="${LLVM_BITMANIP_VERSION}"
-else
-  llvm_version="${LLVM_VERSION}"
-fi
-
 tag_name="${RELEASE_TAG:-HEAD}"
 toolchain_full_name="${toolchain_name}-${tag_name}"
 
@@ -67,7 +61,7 @@ if [ ! -d "${llvm_dir}" ]; then
 fi
 cd "${llvm_dir}"
 git fetch origin
-git checkout --force "${llvm_version}"
+git checkout --force "${LLVM_VERSION}"
 
 # Clang Symlinks
 clang_links_to_create="clang++"
@@ -168,7 +162,7 @@ lowRISC toolchain version: ${tag_name}
 
 Clang version:
   ${clang_version_string}
-  (git: ${LLVM_URL} ${llvm_version})
+  (git: ${LLVM_URL} ${LLVM_VERSION})
 
 GCC version:
   ${gcc_version_string}
@@ -190,7 +184,7 @@ tee "${toolchain_dest}/buildinfo.json" <<BUILDINFO_JSON
   "version": "${tag_name}",
   "clang_version": "${clang_version_string}",
   "clang_url": "${LLVM_URL}",
-  "clang_git": "${llvm_version}",
+  "clang_git": "${LLVM_VERSION}",
   "gcc_version": "${gcc_version_string}",
   "crosstool-ng_version": "${ct_ng_version_string}",
   "crosstool-ng_url": "${CROSSTOOL_NG_URL}",

--- a/sw-versions.sh
+++ b/sw-versions.sh
@@ -9,6 +9,7 @@ export CROSSTOOL_NG_VERSION=5075e1f98e4329502682746cc30fa5c0c5a19d26
 # v4.0.1
 export QEMU_VERSION=23967e5b2a6c6d04b8db766a8a149f3631a7b899
 
-# LLVM 13.0.1 (tag llvmorg-13.0.1)
-export LLVM_URL=https://github.com/llvm/llvm-project.git
-export LLVM_VERSION=75e33f71c2dae584b13a7d1186ae0a038ba98838
+# LLVM 13.0.1 plus hardening patches
+export LLVM_URL=https://github.com/lowRISC/llvm-project.git
+export LLVM_BRANCH=ot-hardening
+export LLVM_VERSION=20a7c03bfa587068b70cf7d8f7eb38fa04d30cd5

--- a/sw-versions.sh
+++ b/sw-versions.sh
@@ -9,9 +9,6 @@ export CROSSTOOL_NG_VERSION=5075e1f98e4329502682746cc30fa5c0c5a19d26
 # v4.0.1
 export QEMU_VERSION=23967e5b2a6c6d04b8db766a8a149f3631a7b899
 
-# master 2020-05-25
+# LLVM 13.0.1 (tag llvmorg-13.0.1)
 export LLVM_URL=https://github.com/llvm/llvm-project.git
-export LLVM_VERSION=fa038e03504c7d0dfd438b1dfdd6da7081e75617
-
-# LLVM 13.0.1-rc3 (tag llvmorg-13.0.1-rc3)
-export LLVM_BITMANIP_VERSION=75e33f71c2dae584b13a7d1186ae0a038ba98838
+export LLVM_VERSION=75e33f71c2dae584b13a7d1186ae0a038ba98838


### PR DESCRIPTION
Updates LLVM to use the `ot-hardening` branch from <https://github.com/lowRISC/llvm-project.git>.
Since the non-bitmanip builds don't seem to be needed anymore (and since we can keep using old releases), those have been removed in this release.