### PR TITLE
Add GitHub Actions workflow for building and releasing toolchains

### DIFF
--- a/.github/workflows/toolchain_build.yml
+++ b/.github/workflows/toolchain_build.yml
@@ -1,0 +1,113 @@
+name: Build toolchains
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - master
+
+env:
+  ARTIFACT_STAGING_DIR: artifact
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - name: rv32imcb
+            display_name: Toolchains targeting Ibex with bit-manipulation extensions
+            target: riscv32-unknown-elf
+            output_dir: /tools/riscv
+            march: rv32imc_zba_zbb_zbc_zbs
+            mabi: ilp32
+            mcmodel: medany
+          - name: rv64imac
+            display_name: GCC and Clang/LLVM toolchains targeting RV64IMAC (Muntjac)
+            target: riscv64-unknown-elf
+            output_dir: /tools/riscv
+            march: rv64imac
+            mabi: lp64
+            mcmodel: medany
+#         - name: multilib-baremetal
+#           display_name: RV64 GCC (Multilib Baremetal)
+#           target: riscv64-unknown-elf
+#           output_dir: /opt/riscv-baremetal-toolchain
+#         - name: multilib-linux
+#           display_name: RV64 GCC (Multilib Linux)
+#           target: riscv64-unknown-linux-gnu
+#           output_dir: /opt/riscv-linux-toolchain
+
+    name: ${{ matrix.display_name }}
+    runs-on: ubuntu-20.04
+    timeout-minutes: 360
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        run: |
+          echo ::group::Install dependencies
+          ./prepare-ubuntu-20.04.sh
+          ./install-crosstool-ng.sh
+          echo ::endgroup::
+
+          echo Preparing toolchain destination directory...
+          sudo mkdir -p /tools/riscv
+          sudo chmod 0777 /tools/riscv
+
+          echo ::group::Set the release tag env var
+          echo "RELEASE_TAG=$(./release_tag.sh)" >> "$GITHUB_ENV"
+          echo ::endgroup::
+
+          echo Creating artifact staging directory...
+          mkdir "$ARTIFACT_STAGING_DIR"
+
+      - name: Build GCC toolchain
+        run: |
+          ./build-gcc-with-args.sh \
+            "lowrisc-toolchain-gcc-${{ matrix.name }}" \
+            "${{ matrix.target }}" \
+            "${{ matrix.output_dir }}" \
+            "${{ matrix.march }}" \
+            "${{ matrix.mabi}}" \
+            "${{ matrix.mcmodel }}" \
+            "${{ matrix.cflags }}"
+
+      - name: Build Clang toolchain
+        run: |
+          ./build-clang-with-args.sh \
+            "lowrisc-toolchain-${{ matrix.name }}" \
+            "${{ matrix.target }}" \
+            "${{ matrix.output_dir }}" \
+            "${{ matrix.march }}" \
+            "${{ matrix.mabi}}" \
+            "${{ matrix.mcmodel }}" \
+            "${{ matrix.cflags }}"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.name }}-toolchains
+          path: ${{ env.ARTIFACT_STAGING_DIR }}
+
+      - name: Check tarballs
+        run: |
+          set -e
+          for f in "${ARTIFACT_STAGING_DIR}"/*.tar.xz; do
+            ./check-tarball.sh "$f"
+          done
+
+      - name: Release
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Create the release if it doesn't already exist.
+          gh release create "$RELEASE_TAG" --prerelease || echo "release exists"
+          # Upload this job's artifacts.
+          gh release upload "$RELEASE_TAG" --clobber \
+            "${ARTIFACT_STAGING_DIR}/lowrisc-toolchain-${{ matrix.name }}-${RELEASE_TAG}.tar.xz" \
+            "${ARTIFACT_STAGING_DIR}/lowrisc-toolchain-gcc-${{ matrix.name }}-${RELEASE_TAG}.tar.xz"

--- a/_build-deps.yml
+++ b/_build-deps.yml
@@ -11,6 +11,15 @@ steps:
   displayName: 'Install build dependencies'
 
 - bash: |
+    # Explicitly include libtinfo in the ncurses linker options since it seems to be
+    # not picked up by configure itself, leading to the following error otherwise:
+    #
+    # /usr/local/bin/libtool  --tag CC  --mode=link gcc  -g -O2   -o nconf nconf-nconf.o nconf-nconf.gui.o nconf-zconf.o -lmenuw -lpanelw -lncursesw
+    # libtool: link: gcc -g -O2 -o nconf nconf-nconf.o nconf-nconf.gui.o nconf-zconf.o  -lmenuw -lpanelw -lncursesw
+    # /opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: nconf-nconf.o: undefined reference to symbol 'keypad'
+    # //lib64/libtinfo.so.5: error adding symbols: DSO missing from command line
+    export CURSES_LIBS="-lcursesw -ltinfo"
+
     ./install-crosstool-ng.sh
   displayName: 'Build and install crosstool-ng'
 

--- a/install-crosstool-ng.sh
+++ b/install-crosstool-ng.sh
@@ -20,11 +20,4 @@ git checkout --force "${CROSSTOOL_NG_VERSION}"
 
 ./bootstrap
 
-# Explicitly include libtinfo in the ncurses linker options since it seems to be
-# not picked up by configure itself, leading to the following error otherwise:
-#
-# /usr/local/bin/libtool  --tag CC  --mode=link gcc  -g -O2   -o nconf nconf-nconf.o nconf-nconf.gui.o nconf-zconf.o -lmenuw -lpanelw -lncursesw
-# libtool: link: gcc -g -O2 -o nconf nconf-nconf.o nconf-nconf.gui.o nconf-zconf.o  -lmenuw -lpanelw -lncursesw
-# /opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: nconf-nconf.o: undefined reference to symbol 'keypad'
-# //lib64/libtinfo.so.5: error adding symbols: DSO missing from command line
-CURSES_LIBS="-lcursesw -ltinfo" ./configure --prefix=/usr/local && make && sudo make install
+./configure --prefix=/usr/local && make && sudo make install

--- a/prepare-ubuntu-20.04.sh
+++ b/prepare-ubuntu-20.04.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -x
+
+# Install prerequisite packages.
+#
+# Notes:
+# - liblzma-dev is removed to prevent it being dynamically linked to GDB.
+# - libxml2-dev is removed to prevent it being dynamically linked to LD.
+sudo apt install -y \
+  bison \
+  curl \
+  flex \
+  gawk \
+  gettext \
+  git \
+  help2man \
+  libffi-dev \
+  libncurses-dev \
+  libpixman-1-dev \
+  libtool-bin \
+  texinfo \
+  xz-utils \
+  zlib1g \
+  zlib1g-dev
+
+sudo apt remove -y \
+  liblzma-dev \
+  libxml2-dev

--- a/release_tag.sh
+++ b/release_tag.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Determine the release tag from Git based on the type of release being made.
+
+set -e
+set -x
+
+# git-describe --always almost does what we want, but we need to connect the
+# `RELEASE_TAG` variable contents to how this build was triggered, which we
+# will find out using `$GITHUB_REF_TYPE` (a GitHub Actions variable).
+#
+# Importantly, a few things are going on here:
+# - If we were triggered by a tag, we need to output exactly the tag name,
+#   so that the artifacts are named correctly. If we cannot do this, the
+#   build needs to fail rather than uploading artifacts to some other
+#   random tag.
+# - If we were triggered by a branch build, we need to be more careful, as
+#   tagged commits are also pushed to branches. Branch builds explicitly use
+#   the longer format so that if the built commit matches a tag, the
+#   `RELEASE_TAG` is not a tag name.
+if [[ "$GITHUB_REF_TYPE" == tag ]]; then
+  echo "$GITHUB_REF_NAME"
+else
+  # Branch Build: Always use '<TAG>-<N>-<SHA>' format.
+  git describe --long
+fi


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that should be equivalent to the Azure pipeline.

This does not remove the existing Azure pipeline.

This workflow:

* Builds GCC and Clang for RV32IMCB and RV64IMAC (plus extras like binutils).
* Checks that no binaries are dynamically linked to non-system libraries.
* Runs for the master branch, PRs to the master branch, and pushed tags.
* Pushed tags trigger a release which is automatically created and given the tarballs.

## Testing

I've tested this works on my fork of this repo:

1. [Release run](https://github.com/jwnrt/lowrisc-toolchains/actions/runs/7196753719) and [the release](https://github.com/jwnrt/lowrisc-toolchains/releases/tag/20231213-1).
2. [Master branch run](https://github.com/jwnrt/lowrisc-toolchains/actions/runs/7196677130).

## Migration strategy

If we choose to accept this PR, I suggest we do the following:

1. Disable the Azure pipeline from the Azure web UI, but leave the configuration files in the repository.
2. Use the GitHub action for at least one real release to ensure it's all working fine.
3. Remove the Azure configuration and documentation from this repo.

## Centos 6 -> Ubuntu 20.04

The important difference to the Azure pipeline is that it builds inside Ubuntu 20.04 and not Centos 6.

GitHub Actions does support using containers (like our centos6 one), but GitHub's actions (like checking out the repo, creating a release, etc.) use Node.js version 20 which is not available for Centos 6.

This is important because Centos 6 uses glibc 2.12 (2010-12-13) and Ubuntu 20.04 has glibc 2.31 (2020-02-01).

Toolchains built against this version of glibc will not work on distributions with an older version. @luismarques is this acceptable? We only support Ubuntu 20.04+ for OpenTitan (and other projects) but these toolchains may be used by others (though they are unsupported).

I understand that bumping the supported glibc version is a big step, so I may be able to look into getting only the build to happen inside Centos 6 as a way to get that support back.