### PR TITLE
Install gh CLI on centos 7

### DIFF
--- a/.github/workflows/toolchain_build.yml
+++ b/.github/workflows/toolchain_build.yml
@@ -54,25 +54,7 @@ jobs:
       - name: Setup environment
         run: |
           echo ::group::Install dependencies
-          yum install -y \
-            sudo \
-            git \
-            shadow-utils \
-            bison \
-            flex \
-            texinfo \
-            help2man \
-            gawk \
-            gettext \
-            curl \
-            xz \
-            ncurses-devel \
-            ncurses-static \
-            pixman-devel \
-            rh-python36 \
-            zlib-devel \
-            zlib-static \
-            libffi-devel
+          ./prepare-centos-7.sh
           echo ::endgroup::
 
           echo ::group::Install crosstool-ng

--- a/prepare-centos-7.sh
+++ b/prepare-centos-7.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -x
+
+# Repository for the `gh` GitHub CLI tool used for creating releases.
+yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+
+yum install -y \
+  sudo \
+  gh \
+  git \
+  shadow-utils \
+  bison \
+  flex \
+  texinfo \
+  help2man \
+  gawk \
+  gettext \
+  curl \
+  xz \
+  ncurses-devel \
+  ncurses-static \
+  pixman-devel \
+  rh-python36 \
+  zlib-devel \
+  zlib-static \
+  libffi-devel


### PR DESCRIPTION
This test adds the `gh` GitHub CLI tool to the CentOS 7 environment. This is used for creating releases.

I've extracted the package list to a `prepare-centos-7.sh` script to match how the other ones worked.