### PR TITLE
Disable newlib syscalls for baremetal target

### DIFF
--- a/lowrisc-toolchain-gcc-rv32imc.config
+++ b/lowrisc-toolchain-gcc-rv32imc.config
@@ -56,5 +56,8 @@ CT_GCC_DEVEL_VCS_git=y
 CT_GCC_DEVEL_URL="https://gcc.gnu.org/git/gcc.git"
 CT_GCC_DEVEL_REVISION="ee5c3db6c5b2c3332912fb4c9cfa2864569ebd9a"
 
+# This is a baremetal target so don't use syscalls.
+CT_LIBC_NEWLIB_DISABLE_SUPPLIED_SYSCALLS=y
+
 # The build script appends a definition of CT_LOCAL_PATCH_DIR down here, that
 # points to the repo's patch directory.

--- a/lowrisc-toolchain-gcc-rv32imcb.config
+++ b/lowrisc-toolchain-gcc-rv32imcb.config
@@ -73,5 +73,8 @@ CT_GCC_DEVEL_VCS_git=y
 CT_GCC_DEVEL_URL="https://github.com/riscv-collab/riscv-gcc"
 CT_GCC_DEVEL_REVISION="73055647d33c0b63a3125c372019d1dac0f8ac34"
 
+# This is a baremetal target so don't use syscalls.
+CT_LIBC_NEWLIB_DISABLE_SUPPLIED_SYSCALLS=y
+
 # The build script appends a definition of CT_LOCAL_PATCH_DIR down here, that
 # points to the repo's patch directory.


### PR DESCRIPTION
@engdoreis and I discovered that newlib generates syscalls when stdio functions are used. This is not desirable and it's preferable to just have linker error instead for baremetal targets.