### PR TITLE
Update LLVM version with single-byte coverage mode

### DIFF
--- a/sw-versions.sh
+++ b/sw-versions.sh
@@ -13,6 +13,7 @@ export QEMU_VERSION=23967e5b2a6c6d04b8db766a8a149f3631a7b899
 # - hardening patches
 # - unratified bitmanip extensions
 # - `.option arch` assembly directive
+# - single-byte code coverage
 export LLVM_URL=https://github.com/lowRISC/llvm-project.git
 export LLVM_BRANCH=ot-llvm-16-hardening
-export LLVM_VERSION=d213f6b2e0bcc561930538ef47b3b5cc900b5b17
+export LLVM_VERSION=50254b2020b89264c88e635745a3808a1cdf9641


### PR DESCRIPTION
Update LLVM version with single-byte coverage mode from PR https://github.com/lowRISC/llvm-project/pull/4

These changes are specific to coverage builds and remain compatible with the current compiler.