### PR TITLE
Build LLVM Toolchain with ninja and lld

### DIFF
--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -142,6 +142,7 @@ cmake "${llvm_dir}/llvm" \
   -DLLVM_ENABLE_BACKTRACES=Off \
   -DLLVM_DEFAULT_TARGET_TRIPLE="${toolchain_target}" \
   -DLLVM_STATIC_LINK_CXX_STDLIB=On \
+  -DLLVM_USE_LINKER="lld" \
   -DCLANG_VENDOR="lowRISC" \
   -DBUG_REPORT_URL="toolchains@lowrisc.org" \
   -DLLVM_INCLUDE_EXAMPLES=Off \

--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -86,7 +86,7 @@ if [ ! -d "$llvm_dir" ]; then
 fi
 cd "${llvm_dir}"
 git fetch origin
-git checkout --force "${LLVM_VERSION}"
+git checkout --force "${LLVM_COMMIT}"
 
 # Clang Symlinks
 clang_links_to_create="clang++"
@@ -179,7 +179,7 @@ lowRISC toolchain version: ${tag_name}
 
 Clang version:
   ${clang_version_string}
-  (git: ${LLVM_URL} ${LLVM_VERSION})
+  (git: ${LLVM_URL} ${LLVM_COMMIT})
 
 C Flags:
   -march=${march} -mabi=${mabi} -mcmodel=${mcmodel}
@@ -194,7 +194,7 @@ tee "${dist_dir}/buildinfo.json" <<BUILDINFO_JSON
   "version": "${tag_name}",
   "clang_version": "${clang_version_string}",
   "clang_url": "${LLVM_URL}",
-  "clang_git": "${LLVM_VERSION}",
+  "clang_git": "${LLVM_COMMIT}",
   "build_date": "${build_date}",
   "build_host": "$(hostname)"
 }

--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -135,6 +135,7 @@ llvm_distribution_components+=";${llvm_tools}"
 
 cmake "${llvm_dir}/llvm" \
   -Wno-dev \
+  -GNinja \
   -DCMAKE_BUILD_TYPE="${build_type}" \
   -DCMAKE_INSTALL_PREFIX="${dist_dir}" \
   -DLLVM_TARGETS_TO_BUILD="RISCV" \

--- a/build-clang-with-args.sh
+++ b/build-clang-with-args.sh
@@ -167,7 +167,6 @@ ls -l "${dist_dir}"
 
 # Write out build info
 set +o pipefail # head causes pipe failures, so we have to switch off pipefail while we use it.
-ct_ng_version_string="$( (set +o pipefail; ct-ng version | head -n1) )"
 clang_version_string="$("${dist_dir}/bin/clang" --version | head -n1)"
 build_date="$(date -u)"
 set -o pipefail
@@ -181,10 +180,6 @@ lowRISC toolchain version: ${tag_name}
 Clang version:
   ${clang_version_string}
   (git: ${LLVM_URL} ${LLVM_VERSION})
-
-Crosstool-ng version:
-  ${ct_ng_version_string}
-  (git: ${CROSSTOOL_NG_URL} ${CROSSTOOL_NG_VERSION})
 
 C Flags:
   -march=${march} -mabi=${mabi} -mcmodel=${mcmodel}

--- a/prepare-host.sh
+++ b/prepare-host.sh
@@ -31,4 +31,5 @@ dnf install -y \
   zlib-devel \
   zlib-static \
   libffi-devel \
-  expat-static
+  expat-static \
+  lld

--- a/prepare-host.sh
+++ b/prepare-host.sh
@@ -33,3 +33,13 @@ dnf install -y \
   libffi-devel \
   expat-static \
   lld
+
+# the version of ninja in almalinux-8 is too old -
+# we need at least version v1.10, so just build it ourselves
+TMP_DIR="$(mktemp -d)"
+git clone https://github.com/ninja-build/ninja.git \
+    --branch v1.12.0 --depth 1 "${TMP_DIR}"
+cd "${TMP_DIR}"
+./configure.py --bootstrap
+install ninja /bin
+rm -rf "{$TMP_DIR}"

--- a/sw-versions.sh
+++ b/sw-versions.sh
@@ -9,7 +9,7 @@
 # - single-byte code coverage
 export LLVM_URL=https://github.com/lowRISC/llvm-project.git
 export LLVM_BRANCH=ot-llvm-16-hardening
-export LLVM_VERSION=dec908d48facb6041c12b95b8ade64719a894917
+export LLVM_COMMIT=dec908d48facb6041c12b95b8ade64719a894917
 
 # RISC-V fork of Binutils 2.35 with bitmanip instruction support
 export BINUTILS_URL=https://github.com/riscv-collab/riscv-binutils-gdb.git


### PR DESCRIPTION
The version of Ninja in the almalinux-8 repository is outdated and causes the following errors to show up:

```multiple outputs aren't (yet?) supported by depslog; bring this up on the mailing list if it affects you```

This was fixed in Ninja v1.10, whereas almalinux-8 bundles v1.8.X, so I opted to build a new enough Ninja from source instead of updating the container image.